### PR TITLE
set circleci/config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,27 @@
+# Javascript Node CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-javascript/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/node:8.9
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "package.json" }}
+          - v1-dependencies-
+      - run: yarn install
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+      - run:
+          name: Running tests
+          command: yarn test
+      - run:
+          name: Running lint
+          command: yarn lint

--- a/__tests__/cli.spec.ts
+++ b/__tests__/cli.spec.ts
@@ -4,7 +4,7 @@ import child_process from 'child_process';
 
 describe('help message', () => {
   test('show help screen', () => {
-    const helpMessage = execa.shellSync('iiopt --help');
+    const helpMessage = execa.shellSync('bin/cli --help');
     expect(helpMessage.stdout).toMatch(/nice/);
   });
 });
@@ -15,14 +15,14 @@ describe('confirm flags and options of cli', () => {
   });
 
   test('output the compressed image to the path designated by --out-dir option', () => {
-    child_process.execSync('iiopt images/illust.png --out-dir tmp');
+    child_process.execSync('bin/cli images/illust.png --out-dir tmp');
     const images = execa.shellSync('ls ./tmp');
     expect(images.stdout).toEqual('illust.png');
   });
 
   test('raise error if both --out-dir option and --overwrite are not given.', () => {
     try {
-      execa.shellSync('iiopt images/illust.png');
+      execa.shellSync('bin/cli images/illust.png');
     } catch (error) {
       expect(error.message).toMatch('--out-dir or --overwrite parameter is needed, specify a `--overwrite`');
     }
@@ -36,7 +36,7 @@ describe('overwrite images', () => {
 
   test("if --overwrite flag is set and --out-dir isn't set, a image is overwritten",() => {
     const rawImage = fs.readFileSync('tmp/illust.png');
-    child_process.execSync('iiopt tmp/illust.png --overwrite');
+    child_process.execSync('bin/cli tmp/illust.png --overwrite');
     const compressedImage = fs.readFileSync('tmp/illust.png');
     expect(rawImage.byteLength).toBeGreaterThan(compressedImage.byteLength);
   });
@@ -50,7 +50,7 @@ describe('compress png images', () => {
   test('output the image to the path that --out-dir option set', () => {
     const rawImage = fs.readFileSync('images/illust.png');
 
-    child_process.execSync('iiopt images/illust.png --out-dir tmp');
+    child_process.execSync('bin/cli images/illust.png --out-dir tmp');
     const compressedImage = fs.readFileSync('tmp/illust.png');
     expect(rawImage.byteLength).toBeGreaterThan(compressedImage.byteLength);
   });
@@ -63,7 +63,7 @@ describe('compress jpg images', () => {
 
   test('output the image to the path that --out-dir option set', () => {
     const rawImage = fs.readFileSync('images/illust.png');
-    child_process.execSync('iiopt images/illust.png --out-dir ./tmp');
+    child_process.execSync('bin/cli images/illust.png --out-dir ./tmp');
     const compressedImage = fs.readFileSync('tmp/illust.png');
     expect(rawImage.byteLength).toBeGreaterThan(compressedImage.byteLength);
   });
@@ -76,7 +76,7 @@ describe('compress jpg images', () => {
     test('output some images to tmp directory', () => {
       const rawJpgImage = fs.readFileSync('images/sample.jpg');
       const rawPngImage = fs.readFileSync('images/illust.png');
-      child_process.execSync('iiopt images/* --out-dir ./tmp/');
+      child_process.execSync('bin/cli images/* --out-dir ./tmp/');
       const compressedJpgImage = fs.readFileSync('tmp/sample.jpg');
       const compressedPngImage = fs.readFileSync('tmp/illust.png');
 


### PR DESCRIPTION
## やりたいこと

iioptでcircleCIが動くようにしたい

## やったこと

- .circle/config.yml の作成
  - sideCIは今のところ入れていません
  - prettier 導入のタイミングでsideCIを検討しようと思います
- cli.spec.tsの修正
  - CI上にて、iiopt コマンドが動かなかったので、bin/cli に置き換えた
  - 事前にyarn link したら解決しましたが、僕以外がテストするときに /usr/local/bin 下を汚してしまうかなと思いまして、yarn link をさせるよりは bin/cli に置き換える方を選びました。