### PR TITLE
CIで現在のブランチに未圧縮画像があるか確認できるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $ iiopt --help
     --install-git-hooks, install script that hooks git pre-commit to compress image automatically
     --overwrite, -o  overwrite images
     --apply-new-files, compress images before git commit.
-    --detect-new-raw-images-from, detect raw images in current branch.
+    --detect-new-raw-images-from, detecting new raw images in a current working branch.
   Example
     $ iiopt images/sample.jpg --out-dir ./compressed # compressed images, and the results are stored into ./compressed directory
     $ iiopt foo.png -o # overwrite foo.png with compressed image
@@ -57,7 +57,7 @@ Currently, also compressed images were recompressed when these were staged.
 If you want to commit already compressed images, use `git commit --no-verify` to skip the git pre-commit hook.
 
 
-### Detect raw images in current branch.
+### Detecting new raw images in a current working branch.
 
 iiopt also has a feature that detects unoptimized images in a current working branch.
 The feature is run by the following command.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ $ iiopt --help
     --install-git-hooks, install script that hooks git pre-commit to compress image automatically
     --overwrite, -o  overwrite images
     --apply-new-files, compress images before git commit.
+    --detect-new-raw-images-from, detect raw images in current branch.
   Example
     $ iiopt images/sample.jpg --out-dir ./compressed # compressed images, and the results are stored into ./compressed directory
     $ iiopt foo.png -o # overwrite foo.png with compressed image
@@ -55,6 +56,17 @@ Notice:
 Currently, also compressed images were recompressed when these were staged.
 If you want to commit already compressed images, use `git commit --no-verify` to skip the git pre-commit hook.
 
+
+### Detect raw images in current branch.
+
+iiopt also has a feature that detects unoptimized images in a current working branch.
+The feature is run by the following command.
+
+```
+iiopt --detect-new-raw-images-from=${branch}
+```
+
+For `${branch}`, you enter the name of the branch to which you want to merge.(ex master, development)
 
 ## Images
 

--- a/__tests__/git_diff.spec.ts
+++ b/__tests__/git_diff.spec.ts
@@ -20,13 +20,15 @@ describe('rawImagesCreatedInCurrentBranch', () => {
 
 
   it('if there are no raws images in current branch', async () => {
-    await expect(gitDiff.rawImagesCreatedInCurrentBranch()).resolves.toEqual([]);
+    const branch = 'origin/master';
+    await expect(gitDiff.detectNewRawImagesFrom(branch)).resolves.toEqual([]);
   });
 
   it('if raw images are added in current branch', async () => {
+    const branch = 'origin/master';
     await copyFileAsync('images/illust.png', './test_images/illust.png');
     await copyFileAsync('images/illust_optimized.png', './test_images/illust_optimized.png');
     await execAsync('git add test_images/illust.png test_images/illust_optimized.png');
-    await expect(gitDiff.rawImagesCreatedInCurrentBranch()).resolves.toEqual(['test_images/illust.png']);
+    await expect(gitDiff.detectNewRawImagesFrom(branch)).resolves.toEqual(['test_images/illust.png']);
   });
 });

--- a/__tests__/git_diff.spec.ts
+++ b/__tests__/git_diff.spec.ts
@@ -1,0 +1,32 @@
+import fs from 'fs';
+import child_process from 'child_process';
+import { promisify } from 'util';
+import * as gitDiff from '../src/git_diff';
+import { Image } from '../src/image';
+
+const execAsync = promisify(child_process.exec);
+const mkdirAsync = promisify(fs.mkdir);
+const copyFileAsync = promisify(fs.copyFile);
+
+describe('rawImagesCreatedInCurrentBranch', () => {
+  beforeAll( async () => {
+    await mkdirAsync('./test_images');
+  });
+
+  afterAll( async () => {
+    await execAsync('git reset HEAD test_images/illust.png test_images/illust_optimized.png');
+    await execAsync('rm -rf test_images');
+  });
+
+
+  it('if there are no raws images in current branch', async () => {
+    await expect(gitDiff.rawImagesCreatedInCurrentBranch()).resolves.toEqual([]);
+  });
+
+  it('if raw images are added in current branch', async () => {
+    await copyFileAsync('images/illust.png', './test_images/illust.png');
+    await copyFileAsync('images/illust_optimized.png', './test_images/illust_optimized.png');
+    await execAsync('git add test_images/illust.png test_images/illust_optimized.png');
+    await expect(gitDiff.rawImagesCreatedInCurrentBranch()).resolves.toEqual(['test_images/illust.png']);
+  });
+});

--- a/__tests__/raw_image_extractor.spec.ts
+++ b/__tests__/raw_image_extractor.spec.ts
@@ -6,8 +6,8 @@ describe('extract png images', () => {
   it('only raw images are extracted', async () => {
     const rawImagePath = './images/illust.png';
     const optimizedImagePath = './images/illust_optimized.png';
-    const images = [rawImagePath, optimizedImagePath].map((path) => new Image(path));
-    const extractor = new RawImageExtractor(images);
-    await expect(extractor.extract()).resolves.toEqual([rawImagePath]);
+    const extractor = new RawImageExtractor([rawImagePath, optimizedImagePath]);
+    const rawImage = new Image(rawImagePath);
+    await expect(extractor.extract()).resolves.toEqual([rawImage]);
   });
 });

--- a/src/apply_new_files.ts
+++ b/src/apply_new_files.ts
@@ -3,26 +3,15 @@ import { optimize } from './optimizer';
 import * as fs from 'fs';
 import { Image } from './image';
 import { RawImageExtractor } from './raw_image_extractor';
+import * as gitDiff from './git_diff';
 import { promisify } from 'util';
 
 const writeFileAsync = promisify(fs.writeFile);
 const execAsync = promisify(child_process.exec);
 
-function extractAddedOrModifiedImageFiles(): string[] {
-  const results = child_process.execSync('git diff --cached --name-status').toString();
-  const regexp = /^[AM]\s.+\.(?:jpg|png)$/gm;
-  const files = results.match(regexp);
-  if (files) {
-    return files.map((file) => file.replace(/^[A|M]\s*/, ''));
-  } else {
-    return [];
-  }
-}
-
 export async function run(opts): Promise<string[]> {
-  const imagePaths = extractAddedOrModifiedImageFiles();
+  const imagePaths = await gitDiff.extractAmongCache();
   if (imagePaths.length === 0 ) { return []; }
-
   const rawImages = await new RawImageExtractor(imagePaths).extract();
   if (rawImages.length === 0) { return []; }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,7 +15,7 @@ const cli = meow(`
     --install-git-hooks, install script that hooks git pre-commit to compress image automatically
     --overwrite, -o  overwrite images
     --apply-new-files, compress images before git commit.
-    --git-diff-among-master, check raw images in current branch.
+    --detect-new-raw-images-from, detect raw images in current branch.
   Example
     $ iiopt images/sample.jpg --out-dir ./compressed # compressed images, and the results are stored into ./compressed directory
     $ iiopt foo.png -o # overwrite foo.png with compressed image
@@ -34,9 +34,8 @@ const cli = meow(`
       type: 'boolean',
       default: false
     },
-    gitDiffAmongMaster: {
-      type: 'boolean',
-      default: false
+    detectNewRawImagesFrom: {
+      type: 'string'
     }
   }
 });
@@ -56,10 +55,11 @@ export async function run() {
   try {
     if (cli.flags.installGitHooks) {
       installGitHooks();
-    } else if (cli.flags.gitDiffAmongMaster) {
-      const rawImagePaths = await gitDiff.rawImagesCreatedInCurrentBranch();
+    } else if (cli.flags.detectNewRawImagesFrom) {
+      const branch = cli.flags.detectNewRawImagesFrom;
+      const rawImagePaths = await gitDiff.detectNewRawImagesFrom(branch);
       if ( rawImagePaths.length > 0 ) {
-        rawImagePaths.forEach(path => console.log(path));
+        rawImagePaths.forEach(path => console.error(path));
         throw new Error('there are raw images in this branch');
       }
     } else if (cli.flags.applyNewFiles) {

--- a/src/git_diff.ts
+++ b/src/git_diff.ts
@@ -1,5 +1,6 @@
 import * as child_process from 'child_process';
 import { promisify } from 'util';
+import { RawImageExtractor } from './raw_image_extractor';
 const execAsync = promisify(child_process.exec);
 
 function extractAddedOrModifiedImageFiles(diffText: string) : string[] {
@@ -15,4 +16,11 @@ function extractAddedOrModifiedImageFiles(diffText: string) : string[] {
 export async function extractAmongCache(): Promise<string[]> {
   const results = await execAsync('git diff --cached --name-status');
   return extractAddedOrModifiedImageFiles(results.stdout);
+}
+
+export async function rawImagesCreatedInCurrentBranch(): Promise<string[]> {
+  const results = await execAsync('git diff --name-status origin/master');
+  const imagePaths = extractAddedOrModifiedImageFiles(results.stdout);
+  const rawImages = await new RawImageExtractor(imagePaths).extract();
+  return rawImages.map(image => image.path);
 }

--- a/src/git_diff.ts
+++ b/src/git_diff.ts
@@ -18,8 +18,8 @@ export async function extractAmongCache(): Promise<string[]> {
   return extractAddedOrModifiedImageFiles(results.stdout);
 }
 
-export async function rawImagesCreatedInCurrentBranch(): Promise<string[]> {
-  const results = await execAsync('git diff --name-status origin/master');
+export async function detectNewRawImagesFrom(branch = 'origin/master'): Promise<string[]> {
+  const results = await execAsync(`git diff --name-status ${branch}`);
   const imagePaths = extractAddedOrModifiedImageFiles(results.stdout);
   const rawImages = await new RawImageExtractor(imagePaths).extract();
   return rawImages.map(image => image.path);

--- a/src/git_diff.ts
+++ b/src/git_diff.ts
@@ -1,0 +1,18 @@
+import * as child_process from 'child_process';
+import { promisify } from 'util';
+const execAsync = promisify(child_process.exec);
+
+function extractAddedOrModifiedImageFiles(diffText: string) : string[] {
+  const regexp = /^[AM]\s.+\.(?:jpg|png)$/gm;
+  const files = diffText.match(regexp);
+  if (files) {
+    return files.map((file) => file.replace(/^[A|M]\s*/, ''));
+  } else {
+    return [];
+  }
+}
+
+export async function extractAmongCache(): Promise<string[]> {
+  const results = await execAsync('git diff --cached --name-status');
+  return extractAddedOrModifiedImageFiles(results.stdout);
+}

--- a/src/out_dir.ts
+++ b/src/out_dir.ts
@@ -6,15 +6,14 @@ import { optimize } from './optimizer';
 import { RawImageExtractor } from './raw_image_extractor';
 
 export async function run(input, opts) {
-  const images = input.map((imagePath) => new Image(imagePath));
-  const rawImagePaths = await new RawImageExtractor(images).extract();
-  if (rawImagePaths.length === 0) {
+  const rawImages = await new RawImageExtractor(input).extract();
+  if (rawImages.length === 0) {
     throw new Error('There are no images to optimize');
   }
 
-  const files = await optimize(rawImagePaths, opts);
+  const files = await optimize(rawImages.map(image => image.path), opts);
   return files.map((file) => {
-    const compressedImage = images.find(image => {
+    const compressedImage = rawImages.find(image => {
       return path.basename(image.path) === path.basename(file.path);
     });
     compressedImage.afterSize = file.data.length;

--- a/src/overwrite.ts
+++ b/src/overwrite.ts
@@ -7,16 +7,15 @@ import { promisify } from 'util';
 const writeFileAsync = promisify(fs.writeFile);
 
 export async function run(input, opts) {
-  const imagePath = input[0];
-  const image = new Image(imagePath);
-  const rawImagePaths = await new RawImageExtractor([image]).extract();
-
-  if (rawImagePaths.length === 0) {
-    throw new Error(`${imagePath} is already optimized`);
+  const rawImages = await new RawImageExtractor(input).extract();
+  const image = rawImages[0];
+  if (!image) {
+    throw new Error(`${input[0]} is already optimized`);
   }
 
-  const files = await optimize(rawImagePaths, opts);
-  await writeFileAsync(imagePath, files[0].data);
+  const rawImagePath = image.path;
+  const files = await optimize(rawImagePath, opts);
+  await writeFileAsync(rawImagePath, files[0].data);
   image.afterSize = files[0].data.length;
   return image.compressionReport();
 }

--- a/src/overwrite.ts
+++ b/src/overwrite.ts
@@ -14,7 +14,7 @@ export async function run(input, opts) {
   }
 
   const rawImagePath = image.path;
-  const files = await optimize(rawImagePath, opts);
+  const files = await optimize([rawImagePath], opts);
   await writeFileAsync(rawImagePath, files[0].data);
   image.afterSize = files[0].data.length;
   return image.compressionReport();

--- a/src/raw_image_extractor.ts
+++ b/src/raw_image_extractor.ts
@@ -1,25 +1,25 @@
 import { Image } from './image';
 
 export class RawImageExtractor {
-  private readonly images: Image[];
+  private readonly inputImages: Image[];
 
-  constructor(images: Image[]) {
-    this.images = images;
+  constructor(imagePaths: string[]) {
+    this.inputImages = imagePaths.map(path => new Image(path));
   }
 
-  async optimizedImages(): Promise<string[]> {
-    const paths: string[] = [];
-    for (const im of this.images) {
-      if (await im.isOptimized()) {
-        paths.push(im.path);
-      }
+  async optimizedImages(): Promise<Image[]> {
+    const paths: Image[] = [];
+    for (const im of this.inputImages) {
+      if (await im.isOptimized()) { paths.push(im); }
     }
     return paths;
   }
 
-  async extract(): Promise<string[]> {
-    const optimizedImagePaths = await this.optimizedImages();
-    const rawImages = this.images.filter((image) => !optimizedImagePaths.includes(image.path));
-    return rawImages.map((image) => image.path);
+  async extract(): Promise<Image[]> {
+    const optimizedImages = await this.optimizedImages();
+    const rawImages = this.inputImages.filter((image) => {
+      return !optimizedImages.includes(image);
+    });
+    return rawImages;
   }
 }

--- a/src/raw_image_extractor.ts
+++ b/src/raw_image_extractor.ts
@@ -1,15 +1,15 @@
 import { Image } from './image';
 
 export class RawImageExtractor {
-  private readonly inputImages: Image[];
+  private readonly images: Image[];
 
   constructor(imagePaths: string[]) {
-    this.inputImages = imagePaths.map(path => new Image(path));
+    this.images = imagePaths.map(path => new Image(path));
   }
 
   async optimizedImages(): Promise<Image[]> {
     const paths: Image[] = [];
-    for (const im of this.inputImages) {
+    for (const im of this.images) {
       if (await im.isOptimized()) { paths.push(im); }
     }
     return paths;
@@ -17,9 +17,8 @@ export class RawImageExtractor {
 
   async extract(): Promise<Image[]> {
     const optimizedImages = await this.optimizedImages();
-    const rawImages = this.inputImages.filter((image) => {
+    return this.images.filter((image) => {
       return !optimizedImages.includes(image);
     });
-    return rawImages;
   }
 }


### PR DESCRIPTION
## やりたいこと

iioptを導入しているGitリポジトリにおいて、現在作業しているbranchに未圧縮の画像が含まれていた場合、検知してくれる機能を作りたい。それをCIに組み込んで、未圧縮画像がPRに含まれていた場合、マージできない仕組みをつくりたい

## 実装方針

- origin/master との git diffを見て、現在の branch で追加されている画像一覧を取得する
- その後、それぞれの画像を読み込んで圧縮されているか判断する
- 圧縮されていなければ、`process.exit(1)` をする

コードで言うとこの部分です
https://github.com/speee/iiopt/pull/8/files#diff-2273498e1df846129978ea3b001a0072R21

## リファクタリングした部分の意図

- RawImageExtractor constructorの引数をimage ではなく image path のarrayにし、戻り値を圧縮後のimage オブジェクトにした
  - 今までは引数がimageだったので、事前にimage のオブジェクトを用意する必要があった
  - 今回の変更によって meow から渡される input の引数をそのまま渡せば、未圧縮なImageのオブジェクトを返す
  - imageオブジェクトを返すので、下記のように一致するimageを検索する処理が不要になった
  - https://github.com/speee/iiopt/pull/8/files#diff-978c9bf2aa5efb59704d23009ae7a515L31

## 動作確認
### 未圧縮の画像がある場合

```
$ cp images/sample.jpg hoge.jpg
$ iiopt --git-diff-among-master
$ git add hoge.jpg
$  git commit -m "test"
[ci_check 2d883a3] test
 1 file changed, 0 insertions(+), 0 deletions(-)
 create mode 100755 hoge.jpg
$ iiopt --detect-new-raw-images-from=origin/master
hoge.jpg
there are raw images in this branch
```

### 最適化済みの画像がある場合

```
$ cp images/illust_optimized.png ./
$ git add illust_optimized.png
$ git commit -m "test optimized image"
[ci_check 61995e2] test optimized image
 1 file changed, 0 insertions(+), 0 deletions(-)
 create mode 100644 illust_optimized.png
$ iiopt --git-diff-among-master
$ ...
```
